### PR TITLE
1.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinymce-light-skin",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Pixabay's Light TinyMCE skin with all assets bundled in the JS.",
   "main": "lib/skin.js",
   "scripts": {

--- a/src/skin.js
+++ b/src/skin.js
@@ -21,3 +21,10 @@ export function unuseInline () {
   skin.unuse()
   inline.unuse()
 }
+
+export default {
+  use: use,
+  unuse: unuse,
+  useInline: useInline,
+  unuseInline: unuseInline
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,7 @@ module.exports = {
     path: './lib',
     filename: 'skin.js',
     library: 'tinymce-light-skin',
-    libraryTarget: 'commonjs2'
+    libraryTarget: 'umd'
   },
   module: {
     loaders: [


### PR DESCRIPTION
Thanks for creating `tinymce-light-skin`!

This PR adjusts the ES2015 module syntax to export a default, changes the compilation within the webpack configuration to support a wider range of consumers via UMD, and bumps a patch version for release.

The example shown in the README `import skin from 'tinymce-ligh-skin'` will only work if there is in fact a default export available. This PR adds that in!