### PR TITLE
2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ browsers.
 import skin from 'tinymce-light-skin'
 
 // append styles to head
-skin.use() 
+skin.use()
 
 // when initializing TinyMCE set skin to false
 tinymce.init({ skin: false })
@@ -28,9 +28,11 @@ tinymce.init({ skin: false })
 // optionaly remove styles from head based on reference count
 skin.unuse()
 
-// inline variants
-skin.useInline()
-skin.unuseInline()
+// to inject content styles into editor's iframe
+tinymce.init({ content_style: skin.contentStyle })
+
+// inline variant
+tinymce.init({ content_style: skin.inlineStyle })
 ```
 
 [1]: https://pixabay.com/en/blog/posts/a-modern-custom-theme-for-tinymce-4-40/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tinymce-light-skin",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "Pixabay's Light TinyMCE skin with all assets bundled in the JS.",
   "main": "lib/skin.js",
   "scripts": {

--- a/src/skin.js
+++ b/src/skin.js
@@ -4,27 +4,19 @@ import inline from '../vendor/light/content.inline.min.css'
 
 export function use () {
   skin.use()
-  content.use()
 }
 
 export function unuse () {
   skin.unuse()
-  content.unuse()
 }
 
-export function useInline () {
-  skin.use()
-  inline.use()
-}
+export const contentStyle = content.toString()
 
-export function unuseInline () {
-  skin.unuse()
-  inline.unuse()
-}
+export const inlineStyle = inline.toString()
 
 export default {
   use: use,
   unuse: unuse,
-  useInline: useInline,
-  unuseInline: unuseInline
+  contentStyle: contentStyle,
+  inlineStyle: inlineStyle
 }

--- a/test/skin.js
+++ b/test/skin.js
@@ -41,4 +41,22 @@ describe('skin', () => {
       assert.equal(document.styleSheets.length, 0)
     })
   })
+
+  describe('default export', () => {
+    it('has the correct shape', () => {
+      const expected = {
+        use: skin.use,
+        unuse: skin.unuse,
+        useInline: skin.useInline,
+        unuseInline: skin.unuseInline,
+        default: {
+          use: skin.use,
+          unuse: skin.unuse,
+          useInline: skin.useInline,
+          unuseInline: skin.unuseInline,
+        }
+      }
+      assert.deepEqual(skin, expected)
+    })
+  })
 })

--- a/test/skin.js
+++ b/test/skin.js
@@ -13,6 +13,10 @@ describe('skin', () => {
   })
 
   describe('use', () => {
+    afterEach(() => {
+      skin.unuse()
+    })
+
     it('adds styles to head', () => {
       assert.equal(document.styleSheets.length, 0)
       skin.use()
@@ -23,6 +27,18 @@ describe('skin', () => {
     it('adds uses data url for font-face', () => {
       skin.use()
       assert(/data:application\/font-woff/.test(document.querySelector('style').textContent))
+    })
+  })
+
+  describe('unuse', () => {
+    beforeEach(() => {
+      skin.use()
+    })
+
+    it('removes styles from head', () => {
+      assert.equal(document.styleSheets.length, 2)
+      skin.unuse()
+      assert.equal(document.styleSheets.length, 0)
     })
   })
 })

--- a/test/skin.js
+++ b/test/skin.js
@@ -20,7 +20,7 @@ describe('skin', () => {
     it('adds styles to head', () => {
       assert.equal(document.styleSheets.length, 0)
       skin.use()
-      assert.equal(document.styleSheets.length, 2)
+      assert.equal(document.styleSheets.length, 1)
       assert(/\.mce-container/.test(document.querySelector('style').textContent))
     })
 
@@ -36,7 +36,7 @@ describe('skin', () => {
     })
 
     it('removes styles from head', () => {
-      assert.equal(document.styleSheets.length, 2)
+      assert.equal(document.styleSheets.length, 1)
       skin.unuse()
       assert.equal(document.styleSheets.length, 0)
     })
@@ -47,16 +47,28 @@ describe('skin', () => {
       const expected = {
         use: skin.use,
         unuse: skin.unuse,
-        useInline: skin.useInline,
-        unuseInline: skin.unuseInline,
+        contentStyle: skin.contentStyle,
+        inlineStyle: skin.inlineStyle,
         default: {
           use: skin.use,
           unuse: skin.unuse,
-          useInline: skin.useInline,
-          unuseInline: skin.unuseInline,
+          contentStyle: skin.contentStyle,
+          inlineStyle: skin.inlineStyle
         }
       }
       assert.deepEqual(skin, expected)
+    })
+  })
+
+  describe('style strings', () => {
+    it('exports content style', () => {
+      assert(/body\{/.test(skin.contentStyle))
+      assert(/\.mce-object/.test(skin.contentStyle))
+    })
+
+    it('exports inline style', () => {
+      assert(/body\{/.test(skin.inlineStyle) === false)
+      assert(/\.mce-object/.test(skin.inlineStyle))
     })
   })
 })

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,8 @@ module.exports = {
   },
   module: {
     loaders: [
-      {test: /\.css$/, loader: 'style-loader/useable!css-loader'},
+      {test: /skin\.min\.css$/, loader: 'style-loader/useable' },
+      {test: /\.css$/, loader: 'css-loader'},
       {test: /\.gif/, loader: 'url-loader'},
       {test: /\.woff/, loader: 'base64-font-loader'}
     ]


### PR DESCRIPTION
This PR adds a bit of test coverage, refactors to support exporting a string of css for content styles, updates the README to reflect our new interface, and bumps a major version for release since we're removing parts of our previously available public API.