### PR TITLE
use `var` instead of `const`

### DIFF
--- a/src/skin.js
+++ b/src/skin.js
@@ -20,7 +20,7 @@ export function unuseInline () {
   inline.unuse()
 }
 
-export const contentStyle = content.toString()
+export var contentStyle = content.toString()
 
 export default {
   use: use,


### PR DESCRIPTION
there are still supported browsers that don't like it (looking at you, Safari 9), and it doesn't get transpiled away